### PR TITLE
Fixed default value assignation of grpc base url

### DIFF
--- a/src/Clarifai/ClarifaiClient.php
+++ b/src/Clarifai/ClarifaiClient.php
@@ -14,10 +14,11 @@ class ClarifaiClient
      * @return V2Client
      */
     public static function grpc($base = null) {
-        if ($base == null) {
+        if ($base === null) {
             $base = getenv('CLARIFAI_GRPC_URL');
-            if (!$base === null)
+            if ($base === false) {
                 $base = 'api.clarifai.com';
+            }
         }
 
         return new V2Client($base, [


### PR DESCRIPTION
If grpc method was called without param (as the example in the readme), having CLARIFAI_GRPC_URL not setted, the getenv was returning a false value, and the following if sentence was not met, so the V2Client constructor was receiving a false in $base param.
This was causing the next error when trying to make a request: "Error: DNS resolution failed".