### PR TITLE
[MRK-3106]set max_receive_message_length

### DIFF
--- a/src/Clarifai/ClarifaiClient.php
+++ b/src/Clarifai/ClarifaiClient.php
@@ -22,7 +22,8 @@ class ClarifaiClient
         }
 
         return new V2Client($base, [
-            'credentials' => ChannelCredentials::createSsl()
+            'credentials' => ChannelCredentials::createSsl(),
+            'grpc.max_receive_message_length' => 128 * 1024 * 1024 // 128 MB
         ]);
     }
 }


### PR DESCRIPTION
Set the grpc channel max receive message length to 128MB.